### PR TITLE
Motion Matching as an AnimationRootNode

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -49,7 +49,7 @@
 #include "synchronizers/mm_synchronizer.h"
 
 #include "mm_animation_library.h"
-#include "mm_animation_node.cpp"
+#include "mm_animation_node.h"
 #include "mm_query.h"
 #include "mm_trajectory_point.h"
 

--- a/src/mm_animation_library.cpp
+++ b/src/mm_animation_library.cpp
@@ -135,7 +135,7 @@ void MMAnimationLibrary::bake_data(const AnimationMixer* p_player, const Skeleto
 MMQueryOutput MMAnimationLibrary::query(const MMQueryInput& p_query_input) {
     // TODO: Use fancier search algorithms
     // TODO: Do this using an offset array instead
-
+    const String lib_name = get_path().get_file().rstrip(".tres") + "/";
     List<StringName> animation_list;
     get_animation_list(&animation_list);
 
@@ -172,8 +172,7 @@ MMQueryOutput MMAnimationLibrary::query(const MMQueryInput& p_query_input) {
             cost = frame_cost;
             result.cost = cost;
             result.matched_frame_data = motion_data.slice(start_frame_index, start_frame_index + dim_count);
-            get_animation_list(&animation_list);
-            result.animation_match = animation_list.get(db_anim_index[start_frame_index / dim_count]);
+            result.animation_match = lib_name + animation_list.get(db_anim_index[start_frame_index / dim_count]);
             result.time_match = db_time_index[start_frame_index / dim_count];
             result.feature_costs = feature_costs;
         }

--- a/src/mm_animation_node.cpp
+++ b/src/mm_animation_node.cpp
@@ -1,0 +1,102 @@
+/**************************************************************************/
+/*  mm_animation_node.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "mm_animation_node.h"
+
+#include "mm_query.h"
+
+StringName MMAnimationNode::MOTION_MATCHING_INPUT_PARAM = "motion_matching_input";
+
+AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+    NodeTimeInfo result;
+
+    if (Engine::get_singleton()->is_editor_hint()) {
+        return result;
+    }
+
+    if (animation_library.is_null()) {
+        return result;
+    }
+
+    MMQueryInput* query_input = Object::cast_to<MMQueryInput>(get_parameter(MOTION_MATCHING_INPUT_PARAM));
+
+    if (!query_input || !query_input->is_valid()) {
+        return result;
+    }
+
+    // Run query
+    animation_library->query(*query_input);
+
+    // const bool has_current_animation = get_animation_tree()->get_animation_player()->get_current_animation().is_empty();
+    // const bool is_same_animation = has_current_animation && result.animation_match == _last_query_output.animation_match;
+    // Play selected animation
+
+    return result;
+}
+
+void MMAnimationNode::get_parameter_list(List<PropertyInfo>* r_list) const {
+    AnimationNode::get_parameter_list(r_list);
+    r_list->push_back(PropertyInfo(Variant::Type::OBJECT, MOTION_MATCHING_INPUT_PARAM));
+}
+
+Variant MMAnimationNode::get_parameter_default_value(const StringName& p_parameter) const {
+    Variant ret = AnimationNode::get_parameter_default_value(p_parameter);
+    if (ret != Variant()) {
+        return ret;
+    }
+
+    if (p_parameter == MOTION_MATCHING_INPUT_PARAM) {
+        Ref<MMQueryInput> p;
+        p.instantiate();
+        return p;
+    }
+
+    return Variant();
+}
+
+bool MMAnimationNode::is_parameter_read_only(const StringName& p_parameter) const {
+    if (AnimationRootNode::is_parameter_read_only(p_parameter)) {
+        return true;
+    }
+
+    if (p_parameter == MOTION_MATCHING_INPUT_PARAM) {
+        return false;
+    }
+
+    return false;
+}
+
+String MMAnimationNode::get_caption() const {
+    return "Motion Matching";
+}
+
+void MMAnimationNode::_bind_methods() {
+    BINDER_PROPERTY_PARAMS(MMAnimationNode, Variant::OBJECT, animation_library, PROPERTY_HINT_RESOURCE_TYPE, "MMAnimationLibrary");
+}

--- a/src/mm_animation_node.cpp
+++ b/src/mm_animation_node.cpp
@@ -40,37 +40,43 @@ StringName MMAnimationNode::MOTION_MATCHING_INPUT_PARAM;
 
 MMAnimationNode::MMAnimationNode() {
     MOTION_MATCHING_INPUT_PARAM = "motion_matching_input";
+    _anim_node.instantiate();
+
+    _anim_node->connect("tree_changed", callable_mp(this, &MMAnimationNode::_tree_changed), CONNECT_REFERENCE_COUNTED);
+    _anim_node->connect("animation_node_renamed", callable_mp(this, &MMAnimationNode::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
+    _anim_node->connect("animation_node_removed", callable_mp(this, &MMAnimationNode::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
 }
 
 AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-    NodeTimeInfo result = get_node_time_info();
-    result.loop_mode = Animation::LoopMode::LOOP_NONE;
+    NodeTimeInfo cur_nti = get_node_time_info();
 
     if (Engine::get_singleton()->is_editor_hint()) {
-        return result;
+        return cur_nti;
     }
 
     if (animation_library.is_null()) {
-        return result;
+        return cur_nti;
     }
 
     const bool is_about_to_end = false; // TODO: Implement this
 
     // We run queries periodically, or when the animation is about to end
-    const bool should_query = (_time_since_last_query > (1.0 / query_frequency)) || is_about_to_end;
+    const bool has_current_animation = !_last_query_output.animation_match.is_empty();
+    const bool should_query = (_time_since_last_query > (1.0 / query_frequency)) || is_about_to_end || !has_current_animation;
 
     if (!should_query) {
         _time_since_last_query += p_playback_info.delta;
-        return result;
+        return play_current_animation(p_playback_info, cur_nti, p_test_only);
     }
-
-    _time_since_last_query = 0.f;
 
     MMQueryInput* query_input = Object::cast_to<MMQueryInput>(get_parameter(MOTION_MATCHING_INPUT_PARAM));
 
     if (!query_input || !query_input->is_valid()) {
-        return result;
+        _time_since_last_query += p_playback_info.delta;
+        return play_current_animation(p_playback_info, cur_nti, p_test_only);
     }
+
+    _time_since_last_query = 0.f;
 
     // Run query
     const MMQueryOutput query_output = animation_library->query(*query_input);
@@ -81,16 +87,27 @@ AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::Play
 
     // Play selected animation
     if (!is_same_animation || !is_same_time) {
-        const String lib_name = animation_library->get_path().get_file().rstrip(".tres");
-        const String animation_match = lib_name + "/" + query_output.animation_match;
+        const String animation_match = get_animation_library_name() + "/" + query_output.animation_match;
         const float time_match = query_output.time_match;
 
-        // TODO: Blend into the matched animation, at the matched time
+        Ref<Animation> anim = process_state->tree->get_animation(animation_match);
+        double anim_size = (double)anim->get_length();
+
+        NodeTimeInfo next_nti = cur_nti;
+        next_nti.length = anim_size;
+        next_nti.position = time_match;
+
+        AnimationMixer::PlaybackInfo pi = p_playback_info;
+        pi.weight = 1.0;
+        pi.time = next_nti.position;
+        pi.looped_flag = Animation::LOOPED_FLAG_NONE;
+        blend_animation(animation_match, p_playback_info);
 
         _last_query_output = query_output;
+        return next_nti;
     }
 
-    return result;
+    return play_current_animation(p_playback_info, cur_nti, p_test_only);
 }
 
 void MMAnimationNode::get_parameter_list(List<PropertyInfo>* r_list) const {
@@ -132,4 +149,56 @@ String MMAnimationNode::get_caption() const {
 void MMAnimationNode::_bind_methods() {
     BINDER_PROPERTY_PARAMS(MMAnimationNode, Variant::OBJECT, animation_library, PROPERTY_HINT_RESOURCE_TYPE, "MMAnimationLibrary");
     BINDER_PROPERTY_PARAMS(MMAnimationNode, Variant::FLOAT, query_frequency);
+}
+
+String MMAnimationNode::get_animation_library_name() const {
+    // TODO: Let store the library name in the node
+    return animation_library->get_path().get_file().rstrip(".tres");
+}
+
+AnimationNode::NodeTimeInfo MMAnimationNode::play_current_animation(const AnimationMixer::PlaybackInfo& p_playback_info, const AnimationNode::NodeTimeInfo& p_current_nti, bool p_test_only) {
+    const StringName animation = get_animation_library_name() + "/" + _last_query_output.animation_match;
+
+    Ref<Animation> anim = process_state->tree->get_animation(animation);
+    double anim_size = (double)anim->get_length();
+
+    bool will_end = Animation::is_greater_or_equal_approx(p_current_nti.position + p_current_nti.delta, p_current_nti.length);
+
+    NodeTimeInfo next_nti = p_current_nti;
+    next_nti.will_end = will_end;
+    next_nti.length = anim_size;
+    next_nti.position = p_playback_info.time;
+
+    if (!p_test_only) {
+        AnimationMixer::PlaybackInfo pi = p_playback_info;
+        pi.weight = 1.0;
+        pi.time = next_nti.position;
+        pi.looped_flag = Animation::LOOPED_FLAG_NONE;
+        blend_animation(animation, pi);
+    }
+
+    return next_nti;
+}
+
+void MMAnimationNode::get_child_nodes(List<ChildNode>* r_child_nodes) {
+    r_child_nodes->push_back(ChildNode{"Animation", _anim_node});
+}
+
+Ref<AnimationNode> MMAnimationNode::get_child_by_name(const StringName& p_name) const {
+    if (p_name == "animation") {
+        return _anim_node;
+    }
+    return Ref<AnimationNode>();
+}
+
+void MMAnimationNode::_tree_changed() {
+    AnimationRootNode::_tree_changed();
+}
+
+void MMAnimationNode::_animation_node_renamed(const ObjectID& p_oid, const String& p_old_name, const String& p_new_name) {
+    AnimationRootNode::_animation_node_renamed(p_oid, p_old_name, p_new_name);
+}
+
+void MMAnimationNode::_animation_node_removed(const ObjectID& p_oid, const StringName& p_node) {
+    AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }

--- a/src/mm_animation_node.cpp
+++ b/src/mm_animation_node.cpp
@@ -40,11 +40,6 @@ StringName MMAnimationNode::MOTION_MATCHING_INPUT_PARAM;
 
 MMAnimationNode::MMAnimationNode() {
     MOTION_MATCHING_INPUT_PARAM = "motion_matching_input";
-    _anim_node.instantiate();
-
-    _anim_node->connect("tree_changed", callable_mp(this, &MMAnimationNode::_tree_changed), CONNECT_REFERENCE_COUNTED);
-    _anim_node->connect("animation_node_renamed", callable_mp(this, &MMAnimationNode::_animation_node_renamed), CONNECT_REFERENCE_COUNTED);
-    _anim_node->connect("animation_node_removed", callable_mp(this, &MMAnimationNode::_animation_node_removed), CONNECT_REFERENCE_COUNTED);
 }
 
 AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
@@ -58,6 +53,9 @@ AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::Play
         return cur_nti;
     }
 
+    _current_animation_info.playback_info = p_playback_info;
+    _current_animation_info.playback_info.weight = 1.0;
+
     const bool is_about_to_end = false; // TODO: Implement this
 
     // We run queries periodically, or when the animation is about to end
@@ -66,14 +64,14 @@ AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::Play
 
     if (!should_query) {
         _time_since_last_query += p_playback_info.delta;
-        return play_current_animation(p_playback_info, cur_nti, p_test_only);
+        return _update_current_animation(p_test_only);
     }
 
     MMQueryInput* query_input = Object::cast_to<MMQueryInput>(get_parameter(MOTION_MATCHING_INPUT_PARAM));
 
     if (!query_input || !query_input->is_valid()) {
         _time_since_last_query += p_playback_info.delta;
-        return play_current_animation(p_playback_info, cur_nti, p_test_only);
+        return _update_current_animation(p_test_only);
     }
 
     _time_since_last_query = 0.f;
@@ -81,7 +79,6 @@ AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::Play
     // Run query
     const MMQueryOutput query_output = animation_library->query(*query_input);
 
-    // const bool has_current_animation = get_animation_tree()->get_animation_player()->get_current_animation().is_empty();
     const bool is_same_animation = query_output.animation_match == _last_query_output.animation_match;
     const bool is_same_time = abs(query_output.time_match - p_playback_info.time) < QUERY_TIME_ERROR;
 
@@ -89,25 +86,39 @@ AnimationNode::NodeTimeInfo MMAnimationNode::_process(const AnimationMixer::Play
     if (!is_same_animation || !is_same_time) {
         const String animation_match = get_animation_library_name() + "/" + query_output.animation_match;
         const float time_match = query_output.time_match;
-
-        Ref<Animation> anim = process_state->tree->get_animation(animation_match);
-        double anim_size = (double)anim->get_length();
-
-        NodeTimeInfo next_nti = cur_nti;
-        next_nti.length = anim_size;
-        next_nti.position = time_match;
-
-        AnimationMixer::PlaybackInfo pi = p_playback_info;
-        pi.weight = 1.0;
-        pi.time = next_nti.position;
-        pi.looped_flag = Animation::LOOPED_FLAG_NONE;
-        blend_animation(animation_match, p_playback_info);
-
+        if (!p_test_only) {
+            _start_transition(animation_match, time_match);
+        }
         _last_query_output = query_output;
-        return next_nti;
     }
 
-    return play_current_animation(p_playback_info, cur_nti, p_test_only);
+    return _update_current_animation(p_test_only);
+}
+
+void MMAnimationNode::_start_transition(const StringName p_animation, float p_time) {
+    _current_animation_info.name = p_animation;
+
+    _current_animation_info.playback_info.time = p_time;
+
+    Ref<Animation> anim = process_state->tree->get_animation(p_animation);
+    _current_animation_info.length = anim->get_length();
+}
+
+AnimationNode::NodeTimeInfo MMAnimationNode::_update_current_animation(bool p_test_only) {
+    const bool will_end = Animation::is_greater_or_equal_approx(
+        _current_animation_info.playback_info.time + _current_animation_info.playback_info.delta,
+        _current_animation_info.length);
+
+    if (!p_test_only) {
+        blend_animation(_current_animation_info.name, _current_animation_info.playback_info);
+    }
+
+    NodeTimeInfo next_nti;
+    next_nti.will_end = will_end;
+    next_nti.length = _current_animation_info.length;
+    next_nti.position = _current_animation_info.playback_info.time;
+    next_nti.delta = _current_animation_info.playback_info.delta;
+    return next_nti;
 }
 
 void MMAnimationNode::get_parameter_list(List<PropertyInfo>* r_list) const {
@@ -154,51 +165,4 @@ void MMAnimationNode::_bind_methods() {
 String MMAnimationNode::get_animation_library_name() const {
     // TODO: Let store the library name in the node
     return animation_library->get_path().get_file().rstrip(".tres");
-}
-
-AnimationNode::NodeTimeInfo MMAnimationNode::play_current_animation(const AnimationMixer::PlaybackInfo& p_playback_info, const AnimationNode::NodeTimeInfo& p_current_nti, bool p_test_only) {
-    const StringName animation = get_animation_library_name() + "/" + _last_query_output.animation_match;
-
-    Ref<Animation> anim = process_state->tree->get_animation(animation);
-    double anim_size = (double)anim->get_length();
-
-    bool will_end = Animation::is_greater_or_equal_approx(p_current_nti.position + p_current_nti.delta, p_current_nti.length);
-
-    NodeTimeInfo next_nti = p_current_nti;
-    next_nti.will_end = will_end;
-    next_nti.length = anim_size;
-    next_nti.position = p_playback_info.time;
-
-    if (!p_test_only) {
-        AnimationMixer::PlaybackInfo pi = p_playback_info;
-        pi.weight = 1.0;
-        pi.time = next_nti.position;
-        pi.looped_flag = Animation::LOOPED_FLAG_NONE;
-        blend_animation(animation, pi);
-    }
-
-    return next_nti;
-}
-
-void MMAnimationNode::get_child_nodes(List<ChildNode>* r_child_nodes) {
-    r_child_nodes->push_back(ChildNode{"Animation", _anim_node});
-}
-
-Ref<AnimationNode> MMAnimationNode::get_child_by_name(const StringName& p_name) const {
-    if (p_name == "animation") {
-        return _anim_node;
-    }
-    return Ref<AnimationNode>();
-}
-
-void MMAnimationNode::_tree_changed() {
-    AnimationRootNode::_tree_changed();
-}
-
-void MMAnimationNode::_animation_node_renamed(const ObjectID& p_oid, const String& p_old_name, const String& p_new_name) {
-    AnimationRootNode::_animation_node_renamed(p_oid, p_old_name, p_new_name);
-}
-
-void MMAnimationNode::_animation_node_removed(const ObjectID& p_oid, const StringName& p_node) {
-    AnimationRootNode::_animation_node_removed(p_oid, p_node);
 }

--- a/src/mm_animation_node.cpp
+++ b/src/mm_animation_node.cpp
@@ -126,7 +126,7 @@ AnimationNode::NodeTimeInfo MMAnimationNode::_update_current_animation(bool p_te
 
 void MMAnimationNode::get_parameter_list(List<PropertyInfo>* r_list) const {
     AnimationNode::get_parameter_list(r_list);
-    r_list->push_back(PropertyInfo(Variant::Type::OBJECT, MOTION_MATCHING_INPUT_PARAM));
+    r_list->push_back(PropertyInfo(Variant::Type::OBJECT, MOTION_MATCHING_INPUT_PARAM, PROPERTY_HINT_RESOURCE_TYPE, "MMQueryInput", PROPERTY_USAGE_STORAGE));
 }
 
 Variant MMAnimationNode::get_parameter_default_value(const StringName& p_parameter) const {
@@ -187,4 +187,8 @@ void MMAnimationNode::_validate_property(PropertyInfo& p_property) const {
 void MMAnimationNode::_bind_methods() {
     BINDER_PROPERTY_PARAMS(MMAnimationNode, Variant::STRING_NAME, library);
     BINDER_PROPERTY_PARAMS(MMAnimationNode, Variant::FLOAT, query_frequency);
+}
+
+bool MMAnimationNode::has_filter() const {
+    return true;
 }

--- a/src/mm_animation_node.h
+++ b/src/mm_animation_node.h
@@ -43,10 +43,10 @@ public:
     GETSET(Ref<MMAnimationLibrary>, animation_library)
 
     virtual AnimationNode::NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
-    virtual void get_parameter_list(List<PropertyInfo>* r_list) const;
-    virtual Variant get_parameter_default_value(const StringName& p_parameter) const;
-    virtual bool is_parameter_read_only(const StringName& p_parameter) const;
-    virtual String get_caption() const;
+    virtual void get_parameter_list(List<PropertyInfo>* r_list) const override;
+    virtual Variant get_parameter_default_value(const StringName& p_parameter) const override;
+    virtual bool is_parameter_read_only(const StringName& p_parameter) const override;
+    virtual String get_caption() const override;
 
     static StringName MOTION_MATCHING_INPUT_PARAM;
 

--- a/src/mm_animation_node.h
+++ b/src/mm_animation_node.h
@@ -52,21 +52,23 @@ public:
     virtual Variant get_parameter_default_value(const StringName& p_parameter) const override;
     virtual bool is_parameter_read_only(const StringName& p_parameter) const override;
     virtual String get_caption() const override;
-    virtual void get_child_nodes(List<ChildNode>* r_child_nodes) override;
-    virtual Ref<AnimationNode> get_child_by_name(const StringName& p_name) const;
 
     static StringName MOTION_MATCHING_INPUT_PARAM;
 
 protected:
     static void _bind_methods();
 
-    virtual void _tree_changed() override;
-    virtual void _animation_node_renamed(const ObjectID& p_oid, const String& p_old_name, const String& p_new_name) override;
-    virtual void _animation_node_removed(const ObjectID& p_oid, const StringName& p_node) override;
-
 private:
-    Ref<AnimationNodeAnimation> _anim_node;
-    AnimationNode::NodeTimeInfo play_current_animation(const AnimationMixer::PlaybackInfo& p_playback_info, const AnimationNode::NodeTimeInfo& p_current_nti, bool p_test_only);
+    struct AnimationInfo {
+        StringName name;
+        float length;
+        AnimationMixer::PlaybackInfo playback_info;
+    };
+
+    AnimationInfo _current_animation_info;
+
+    void _start_transition(const StringName p_animation, float p_time);
+    AnimationNode::NodeTimeInfo _update_current_animation(bool p_test_only);
 
     String get_animation_library_name() const;
     MMQueryOutput _last_query_output;

--- a/src/mm_animation_node.h
+++ b/src/mm_animation_node.h
@@ -40,7 +40,11 @@ class MMAnimationNode : public AnimationRootNode {
     GDCLASS(MMAnimationNode, AnimationRootNode);
 
 public:
+    MMAnimationNode();
+    virtual ~MMAnimationNode() = default;
+
     GETSET(Ref<MMAnimationLibrary>, animation_library)
+    GETSET(float, query_frequency, 2.0f)
 
     virtual AnimationNode::NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
     virtual void get_parameter_list(List<PropertyInfo>* r_list) const override;
@@ -54,7 +58,8 @@ protected:
     static void _bind_methods();
 
 private:
-    // MMQueryOutput _last_query_output;
+    MMQueryOutput _last_query_output;
+    float _time_since_last_query{0.f};
 };
 
 #endif // MM_ANIMATION_NODE_H

--- a/src/mm_animation_node.h
+++ b/src/mm_animation_node.h
@@ -31,6 +31,7 @@
 #ifndef MM_ANIMATION_NODE_H
 #define MM_ANIMATION_NODE_H
 
+#include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_tree.h"
 
 #include "common.h"
@@ -51,13 +52,23 @@ public:
     virtual Variant get_parameter_default_value(const StringName& p_parameter) const override;
     virtual bool is_parameter_read_only(const StringName& p_parameter) const override;
     virtual String get_caption() const override;
+    virtual void get_child_nodes(List<ChildNode>* r_child_nodes) override;
+    virtual Ref<AnimationNode> get_child_by_name(const StringName& p_name) const;
 
     static StringName MOTION_MATCHING_INPUT_PARAM;
 
 protected:
     static void _bind_methods();
 
+    virtual void _tree_changed() override;
+    virtual void _animation_node_renamed(const ObjectID& p_oid, const String& p_old_name, const String& p_new_name) override;
+    virtual void _animation_node_removed(const ObjectID& p_oid, const StringName& p_node) override;
+
 private:
+    Ref<AnimationNodeAnimation> _anim_node;
+    AnimationNode::NodeTimeInfo play_current_animation(const AnimationMixer::PlaybackInfo& p_playback_info, const AnimationNode::NodeTimeInfo& p_current_nti, bool p_test_only);
+
+    String get_animation_library_name() const;
     MMQueryOutput _last_query_output;
     float _time_since_last_query{0.f};
 };

--- a/src/mm_animation_node.h
+++ b/src/mm_animation_node.h
@@ -52,6 +52,7 @@ public:
     virtual Variant get_parameter_default_value(const StringName& p_parameter) const override;
     virtual bool is_parameter_read_only(const StringName& p_parameter) const override;
     virtual String get_caption() const override;
+    virtual bool has_filter() const;
 
     static StringName MOTION_MATCHING_INPUT_PARAM;
 
@@ -63,7 +64,7 @@ protected:
 private:
     struct AnimationInfo {
         StringName name;
-        float length;
+        double length;
         AnimationMixer::PlaybackInfo playback_info;
     };
 

--- a/src/mm_animation_node.h
+++ b/src/mm_animation_node.h
@@ -44,7 +44,7 @@ public:
     MMAnimationNode();
     virtual ~MMAnimationNode() = default;
 
-    GETSET(Ref<MMAnimationLibrary>, animation_library)
+    GETSET(StringName, library);
     GETSET(float, query_frequency, 2.0f)
 
     virtual AnimationNode::NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
@@ -56,6 +56,8 @@ public:
     static StringName MOTION_MATCHING_INPUT_PARAM;
 
 protected:
+    void _validate_property(PropertyInfo& p_property) const;
+
     static void _bind_methods();
 
 private:
@@ -70,7 +72,6 @@ private:
     void _start_transition(const StringName p_animation, float p_time);
     AnimationNode::NodeTimeInfo _update_current_animation(bool p_test_only);
 
-    String get_animation_library_name() const;
     MMQueryOutput _last_query_output;
     float _time_since_last_query{0.f};
 };

--- a/src/mm_animation_node.h
+++ b/src/mm_animation_node.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  mm_animation_node.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,54 +28,33 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#ifndef MM_ANIMATION_NODE_H
+#define MM_ANIMATION_NODE_H
 
-#include "mm_character.h"
+#include "scene/animation/animation_tree.h"
 
-#ifdef TOOLS_ENABLED
-#include "editor/mm_editor.h"
-#include "editor/mm_editor_gizmo_plugin.h"
-#include "editor/mm_editor_plugin.h"
-#endif
-
-#include "features/mm_bone_data_feature.h"
-#include "features/mm_feature.h"
-#include "features/mm_trajectory_feature.h"
-
-#include "modifiers/damped_skeleton_modifier.h"
-
-#include "synchronizers/mm_clamp_synchronizer.h"
-#include "synchronizers/mm_rootmotion_synchronizer.h"
-#include "synchronizers/mm_synchronizer.h"
-
+#include "common.h"
 #include "mm_animation_library.h"
-#include "mm_animation_node.cpp"
-#include "mm_query.h"
-#include "mm_trajectory_point.h"
 
-void initialize_motion_matching_module(ModuleInitializationLevel p_level) {
-    if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-        ClassDB::register_abstract_class<MMFeature>();
-        ClassDB::register_class<MMTrajectoryFeature>();
-        ClassDB::register_class<MMBoneDataFeature>();
+class MMAnimationNode : public AnimationRootNode {
+    GDCLASS(MMAnimationNode, AnimationRootNode);
 
-        ClassDB::register_class<MMAnimationLibrary>();
-        ClassDB::register_class<MMAnimationNode>();
-        ClassDB::register_class<MMQueryInput>();
+public:
+    GETSET(Ref<MMAnimationLibrary>, animation_library)
 
-        ClassDB::register_class<MMCharacter>();
+    virtual AnimationNode::NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+    virtual void get_parameter_list(List<PropertyInfo>* r_list) const;
+    virtual Variant get_parameter_default_value(const StringName& p_parameter) const;
+    virtual bool is_parameter_read_only(const StringName& p_parameter) const;
+    virtual String get_caption() const;
 
-        ClassDB::register_class<DampedSkeletonModifier>();
-        ClassDB::register_abstract_class<MMSynchronizer>();
-        ClassDB::register_class<MMClampSynchronizer>();
-        ClassDB::register_class<MMRootMotionSynchronizer>();
-    }
-#ifdef TOOLS_ENABLED
-    if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
-        EditorPlugins::add_by_type<MMEditorPlugin>();
-    }
-#endif
-}
+    static StringName MOTION_MATCHING_INPUT_PARAM;
 
-void uninitialize_motion_matching_module(ModuleInitializationLevel p_level) {
-}
+protected:
+    static void _bind_methods();
+
+private:
+    // MMQueryOutput _last_query_output;
+};
+
+#endif // MM_ANIMATION_NODE_H

--- a/src/mm_character.cpp
+++ b/src/mm_character.cpp
@@ -36,57 +36,11 @@
 
 #include <cstdint>
 
-constexpr float QUERY_TIME_ERROR = 0.05;
-
 MMCharacter::MMCharacter()
     : CharacterBody3D() {
 }
 
 MMCharacter::~MMCharacter() {
-}
-
-MMQueryOutput MMCharacter::query(const MMQueryInput& query_input) {
-
-    List<StringName> animation_libraries;
-    _animation_player->get_animation_library_list(&animation_libraries);
-    MMQueryOutput result;
-
-    bool found_anim_library = false;
-
-    // We should do something more sophisticated here,
-    // but for now we just use the first motion matching library we find
-    for (int64_t i = 0; i < animation_libraries.size(); i++) {
-        const StringName& library_name = animation_libraries.get(i);
-        if (!library_name) {
-            continue;
-        }
-        Ref<MMAnimationLibrary> library = _animation_player->get_animation_library(library_name);
-        if (library.is_null()) {
-            continue;
-        }
-        List<StringName> animation_list;
-        library->get_animation_list(&animation_list);
-        if (library.is_null() || animation_list.is_empty()) {
-            continue;
-        }
-
-        result = library->query(query_input);
-        result.animation_match = String(library_name) + "/" + result.animation_match;
-        found_anim_library = true;
-        break;
-    }
-
-    ERR_FAIL_COND_V_MSG(
-        !found_anim_library,
-        result,
-        "No Motion Matching animation library found in the MMAnimationPlayer");
-
-    ERR_FAIL_COND_V_MSG(
-        result.animation_match.is_empty(),
-        result,
-        "No animation match found, check that your animation libraries aren't empty");
-
-    return result;
 }
 
 void MMCharacter::_update_character(float delta_t) {
@@ -311,64 +265,36 @@ void MMCharacter::_fall_to_floor(MMTrajectoryPoint& point, float delta_t) {
     }
 }
 
-void MMCharacter::_on_animation_finished(StringName p_animation_name) {
-    _force_transition = true;
-}
-
 void MMCharacter::_fill_query_input(MMQueryInput& input) {
     input.controller_velocity = get_velocity();
     input.trajectory = get_trajectory();
     input.trajectory_history = get_trajectory_history();
     input.controller_transform = get_global_transform();
-    input.character_transform = _skeleton->get_global_transform();
+    input.character_transform = skeleton->get_global_transform();
     input.skeleton_state = _skeleton_state;
 }
 
-void MMCharacter::_update_query(double delta_t) {
-    const bool should_query = (_time_since_last_query > (1.0 / query_frequency)) || _force_transition;
-    if (should_query) {
-        _time_since_last_query = 0.f;
-        _force_transition = false;
-
-        // Fill query_input with data from the controller
+void MMCharacter::_update_query() {
+    // Fill query_input with data from the controller
+    if (animation_tree) {
         Ref<MMQueryInput> query_input;
         query_input.instantiate();
         _fill_query_input(**query_input);
-
-        if (_animation_tree) {
-            _animation_tree->set(
-                "parameters/" + MMAnimationNode::MOTION_MATCHING_INPUT_PARAM,
-                query_input);
-        }
-
-        // // Run query
-        // const MMQueryOutput result = query(**query_input);
-
-        // // Play selected animation
-        // // TODO: It would be nice if we could use _animation_player->get_current_animation() here instead
-        // // but that sometimes returns an empty string :/
-
-        // const bool has_current_animation = !_animation_player->get_current_animation().is_empty();
-        // const bool is_same_animation = has_current_animation && result.animation_match == _last_query_output.animation_match;
-        // const bool is_same_time = has_current_animation && abs(result.time_match - _animation_player->get_current_animation_position()) < QUERY_TIME_ERROR;
-
-        // if (!is_same_animation || !is_same_time) {
-        //     _animation_player->play(result.animation_match);
-        //     _animation_player->seek(result.time_match);
-        //     emit_signal("on_query_result", _output_to_dict(result));
-        //     _last_query_output = result;
-        // }
+        animation_tree->set(
+            "parameters/" + MMAnimationNode::MOTION_MATCHING_INPUT_PARAM,
+            query_input);
     }
-    _time_since_last_query += delta_t;
 }
 
 void MMCharacter::_apply_root_motion() {
-    _skeleton->set_quaternion(
-        _skeleton->get_quaternion() * _animation_player->get_root_motion_rotation());
+    skeleton->set_quaternion(
+        skeleton->get_quaternion() * animation_tree->get_root_motion_rotation());
 
-    const Vector3 movement_delta = (_animation_player->get_root_motion_rotation_accumulator().inverse() * _skeleton->get_quaternion()).xform(_animation_player->get_root_motion_position());
+    const Vector3 movement_delta = (animation_tree->get_root_motion_rotation_accumulator().inverse() *
+                                    skeleton->get_quaternion())
+                                       .xform(animation_tree->get_root_motion_position());
 
-    _skeleton->set_global_position(_skeleton->get_global_position() + movement_delta);
+    skeleton->set_global_position(skeleton->get_global_position() + movement_delta);
 }
 
 void MMCharacter::_update_synchronizer(double delta_t) {
@@ -378,18 +304,18 @@ void MMCharacter::_update_synchronizer(double delta_t) {
 
     // TODO: This is wrong, we should not be changing the character position directly!
     // See #33 for more information
-    MMSyncResult sync_result = synchronizer->sync(this, _skeleton, delta_t);
+    MMSyncResult sync_result = synchronizer->sync(this, skeleton, delta_t);
     set_global_position(sync_result.controller_position);
     set_quaternion(sync_result.controller_rotation);
-    _skeleton->set_global_position(sync_result.character_position);
-    _skeleton->set_quaternion(sync_result.character_rotation);
+    skeleton->set_global_position(sync_result.character_position);
+    skeleton->set_quaternion(sync_result.character_rotation);
 }
 
 void MMCharacter::_fill_current_skeleton_state(SkeletonState& p_state) const {
-    Transform3D root_bone_pose = _skeleton->get_bone_global_pose(_root_bone_idx);
+    Transform3D root_bone_pose = skeleton->get_bone_global_pose(_root_bone_idx);
 
-    for (int b = 0; b < _skeleton->get_bone_count(); ++b) {
-        Transform3D bone_pose = _skeleton->get_bone_global_pose(b);
+    for (int b = 0; b < skeleton->get_bone_count(); ++b) {
+        Transform3D bone_pose = skeleton->get_bone_global_pose(b);
         p_state[b].pos = root_bone_pose.xform(bone_pose.origin);
         p_state[b].vel = Vector3();
         p_state[b].rot = bone_pose.basis.get_rotation_quaternion();
@@ -405,10 +331,10 @@ void MMCharacter::_reset_skeleton_state() {
 }
 
 void MMCharacter::_update_skeleton_state(double delta_t) {
-    SkeletonState current_state(_skeleton);
+    SkeletonState current_state(skeleton);
     _fill_current_skeleton_state(current_state);
 
-    for (int b = 0; b < _skeleton->get_bone_count(); ++b) {
+    for (int b = 0; b < skeleton->get_bone_count(); ++b) {
         BoneState& state = _skeleton_state[b];
         const BoneState& current = current_state[b];
 
@@ -435,28 +361,19 @@ Dictionary MMCharacter::_output_to_dict(const MMQueryOutput& output) {
 }
 
 AnimationMixer* MMCharacter::get_animation_mixer() const {
-    Node* current_node = get_node(animation_player_path);
-    return cast_to<AnimationMixer>(current_node);
-}
-
-Skeleton3D* MMCharacter::get_skeleton() const {
-    Node* current_skeleton = get_node(skeleton_path);
-    return cast_to<Skeleton3D>(current_skeleton);
+    return animation_tree;
 }
 
 void MMCharacter::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_trajectory"), &MMCharacter::get_trajectory_typed_array);
     ClassDB::bind_method(D_METHOD("get_trajectory_history"), &MMCharacter::get_trajectory_history_typed_array);
-    ClassDB::bind_method(D_METHOD("_on_animation_finished", "anim"), &MMCharacter::_on_animation_finished);
     ClassDB::bind_method(D_METHOD("get_skeleton_state"), &MMCharacter::get_skeleton_state);
 
     ADD_SIGNAL(MethodInfo("on_query_result", PropertyInfo(Variant::DICTIONARY, "data")));
 
     ADD_GROUP("Motion Matching", "");
-    BINDER_PROPERTY_PARAMS(MMCharacter, Variant::NODE_PATH, skeleton_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton3D");
-    BINDER_PROPERTY_PARAMS(MMCharacter, Variant::NODE_PATH, animation_player_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "AnimationPlayer");
-    BINDER_PROPERTY_PARAMS(MMCharacter, Variant::NODE_PATH, animation_tree_path, PROPERTY_HINT_NODE_PATH_VALID_TYPES, "AnimationTree");
-    BINDER_PROPERTY_PARAMS(MMCharacter, Variant::FLOAT, query_frequency);
+    BINDER_PROPERTY_PARAMS(MMCharacter, Variant::OBJECT, skeleton, PROPERTY_HINT_NODE_TYPE, "Skeleton3D");
+    BINDER_PROPERTY_PARAMS(MMCharacter, Variant::OBJECT, animation_tree, PROPERTY_HINT_NODE_TYPE, "AnimationTree");
     BINDER_PROPERTY_PARAMS(MMCharacter, Variant::OBJECT, synchronizer, PROPERTY_HINT_RESOURCE_TYPE, "MMSynchronizer");
 
     ADD_GROUP("Movement", "");
@@ -476,7 +393,6 @@ void MMCharacter::_bind_methods() {
 void MMCharacter::_notification(int p_what) {
     switch (p_what) {
     case NOTIFICATION_PHYSICS_PROCESS: {
-
         if (Engine::get_singleton()->is_editor_hint()) {
             return;
         }
@@ -484,13 +400,13 @@ void MMCharacter::_notification(int p_what) {
 
         _update_character(delta);
 
-        if (!_skeleton) {
+        if (!skeleton) {
             return;
         }
 
         _update_skeleton_state(delta);
 
-        _update_query(delta);
+        _update_query();
 
         _apply_root_motion();
 
@@ -510,22 +426,14 @@ void MMCharacter::_notification(int p_what) {
         _trajectory.resize(trajectory_point_count + 1);
         _trajectory_history.resize(history_point_count);
 
-        _animation_tree = cast_to<AnimationTree>(get_node(animation_tree_path));
-        _animation_player = cast_to<AnimationPlayer>(get_node(animation_player_path));
-        if (_animation_player) {
-            _animation_player->connect("animation_finished", Callable(this, "_on_animation_finished"));
-            _animation_player->set_callback_mode_process(AnimationMixer::AnimationCallbackModeProcess::ANIMATION_CALLBACK_MODE_PROCESS_PHYSICS);
-        }
+        if (skeleton && animation_tree) {
+            StringName root_node_path = animation_tree->get_root_motion_track().get_concatenated_subnames();
+            _root_bone_idx = skeleton->find_bone(root_node_path);
 
-        _skeleton = cast_to<Skeleton3D>(get_node(skeleton_path));
-        if (_skeleton && _animation_player) {
-            StringName root_node_path = _animation_player->get_root_motion_track().get_concatenated_subnames();
-            _root_bone_idx = _skeleton->find_bone(root_node_path);
+            skeleton->set_as_top_level(true);
+            skeleton->reset_bone_poses();
 
-            _skeleton->set_as_top_level(true);
-            _skeleton->reset_bone_poses();
-
-            _skeleton_state = SkeletonState(_skeleton);
+            _skeleton_state = SkeletonState(skeleton);
             _reset_skeleton_state();
         }
     } break;

--- a/src/mm_character.h
+++ b/src/mm_character.h
@@ -47,34 +47,11 @@
 class MMCharacter : public CharacterBody3D {
     GDCLASS(MMCharacter, CharacterBody3D)
 
-private:
-    // Controller
-    Vector3 _spring_acceleration;
-
-    // Trajectory
-    std::vector<MMTrajectoryPoint> _trajectory;
-    std::vector<MMTrajectoryPoint> _trajectory_history;
-    CircularBuffer<MMTrajectoryPoint> _history_buffer{HISTORY_BUFFER_SIZE};
-
-    // Motion Matching
-    Skeleton3D* _skeleton{nullptr};
-    AnimationPlayer* _animation_player{nullptr};
-    AnimationTree* _animation_tree{nullptr};
-    float _time_since_last_query{0.f};
-    bool _force_transition{false};
-    MMQueryOutput _last_query_output;
-
-    // Skeleton State
-    SkeletonState _skeleton_state;
-    int32_t _root_bone_idx{-1};
-
 public:
     MMCharacter();
     virtual ~MMCharacter();
 
 public:
-    MMQueryOutput query(const MMQueryInput& p_query_input);
-
     const std::vector<MMTrajectoryPoint>& get_trajectory() const {
         return _trajectory;
     }
@@ -116,7 +93,6 @@ public:
     }
 
     AnimationMixer* get_animation_mixer() const;
-    Skeleton3D* get_skeleton() const;
 
     // Trajectory
     GETSET(float, trajectory_delta_time, 0.5f);
@@ -132,10 +108,8 @@ public:
     GETSET(Vector3, target_velocity);
 
     // Motion Matching
-    GETSET(NodePath, skeleton_path)
-    GETSET(NodePath, animation_player_path)
-    GETSET(NodePath, animation_tree_path)
-    GETSET(float, query_frequency, 2.0f)
+    GETSET(Skeleton3D*, skeleton)
+    GETSET(AnimationTree*, animation_tree)
     GETSET(Ref<MMSynchronizer>, synchronizer)
 
 protected:
@@ -157,12 +131,9 @@ private:
     void _fill_collision_state(const Ref<PhysicsTestMotionResult3D> collision_result, MMCollisionState& state);
     void _fall_to_floor(MMTrajectoryPoint& point, float delta_t);
 
-    // Callbacks
-    void _on_animation_finished(StringName p_animation_name);
-
     // Motion Matching
     void _fill_query_input(MMQueryInput& input);
-    void _update_query(double delta_t);
+    void _update_query();
     void _apply_root_motion();
     void _update_synchronizer(double delta_t);
 
@@ -172,6 +143,19 @@ private:
     void _update_skeleton_state(double delta_t);
 
     static Dictionary _output_to_dict(const MMQueryOutput& output);
+
+private:
+    // Controller
+    Vector3 _spring_acceleration;
+
+    // Trajectory
+    std::vector<MMTrajectoryPoint> _trajectory;
+    std::vector<MMTrajectoryPoint> _trajectory_history;
+    CircularBuffer<MMTrajectoryPoint> _history_buffer{HISTORY_BUFFER_SIZE};
+
+    // Skeleton State
+    SkeletonState _skeleton_state;
+    int32_t _root_bone_idx{-1};
 };
 
 #endif // MM_CHARACTER_H

--- a/src/mm_character.h
+++ b/src/mm_character.h
@@ -156,6 +156,9 @@ private:
     // Skeleton State
     SkeletonState _skeleton_state;
     int32_t _root_bone_idx{-1};
+
+    // Motion Matching parameters
+    List<StringName> _mm_input_params;
 };
 
 #endif // MM_CHARACTER_H

--- a/src/mm_character.h
+++ b/src/mm_character.h
@@ -42,6 +42,7 @@
 #include "scene/3d/physics/character_body_3d.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/animation/animation_player.h"
+#include "scene/animation/animation_tree.h"
 
 class MMCharacter : public CharacterBody3D {
     GDCLASS(MMCharacter, CharacterBody3D)
@@ -58,6 +59,7 @@ private:
     // Motion Matching
     Skeleton3D* _skeleton{nullptr};
     AnimationPlayer* _animation_player{nullptr};
+    AnimationTree* _animation_tree{nullptr};
     float _time_since_last_query{0.f};
     bool _force_transition{false};
     MMQueryOutput _last_query_output;
@@ -132,6 +134,7 @@ public:
     // Motion Matching
     GETSET(NodePath, skeleton_path)
     GETSET(NodePath, animation_player_path)
+    GETSET(NodePath, animation_tree_path)
     GETSET(float, query_frequency, 2.0f)
     GETSET(Ref<MMSynchronizer>, synchronizer)
 

--- a/src/mm_query.h
+++ b/src/mm_query.h
@@ -31,12 +31,16 @@
 #ifndef MM_QUERY_H
 #define MM_QUERY_H
 
+#include "core/object/ref_counted.h"
 #include "scene/3d/skeleton_3d.h"
 
 #include "mm_bone_state.h"
 #include "mm_trajectory_point.h"
 
-struct MMQueryInput {
+class MMQueryInput : public RefCounted {
+    GDCLASS(MMQueryInput, RefCounted);
+
+public:
     // Add data required for the query here
     Vector3 controller_velocity;
     Transform3D controller_transform;
@@ -44,6 +48,15 @@ struct MMQueryInput {
     std::vector<MMTrajectoryPoint> trajectory;
     std::vector<MMTrajectoryPoint> trajectory_history;
     SkeletonState skeleton_state;
+
+    bool is_valid() const {
+        // Add validation logic here
+        return !trajectory.empty();
+    }
+
+protected:
+    static void _bind_methods() {
+    }
 };
 
 struct MMQueryOutput {


### PR DESCRIPTION
- [x] Turn `MMQueryInput` into a `RefCounted` object
- [x] Add `MMQueryInput` as a animation node parameter
- [x] Run a motion matching query on the motion matching node's animation library
- [x] Figure out how `blend_animation` works so that we can play/blend the animation result
- [x] Play/Blend the animation result


